### PR TITLE
feat: use actions/github-script instead of running node directly

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           script: |
             const { default: script } = await import(`${process.env.GITHUB_WORKSPACE}/check-pr-status.mjs`);
-            await script(github, '${{ github.repository_owner }}', '${{ github.repository }}', ${{ steps.cpr.outputs.pull-request-number }});
+            await script(github, '${{ github.repository }}', ${{ steps.cpr.outputs.pull-request-number }});
 
       - name: Auto-approve the PR
         uses: juliangruber/approve-pull-request-action@v1

--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -12,14 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        with:
-          # to access `--experimental-fetch`
-          node-version: '17'
-
       - name: Run automation script
+        uses: actions/github-script@v6
         id: updt
-        run: node --experimental-fetch build-automation.mjs
+        with:
+          script: |
+            const { default: script } = await import(`${process.env.GITHUB_WORKSPACE}/build-automation.mjs`);
+            await script(github);
 
       - name: Create update PR
         id: cpr
@@ -35,9 +34,11 @@ jobs:
             @nodejs/docker
 
       - name: Check CI status periodically
-        env:
-          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node --experimental-fetch check-pr-status.mjs ${{ github.repository }} ${{ steps.cpr.outputs.pull-request-number }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { default: script } = await import(`${process.env.GITHUB_WORKSPACE}/check-pr-status.mjs`);
+            await script(github, '${{ github.repository_owner }}', '${{ github.repository }}', ${{ steps.cpr.outputs.pull-request-number }});
 
       - name: Auto-approve the PR
         uses: juliangruber/approve-pull-request-action@v1

--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -7,26 +7,25 @@ const exec = promisify(child_process.exec);
 // a function that queries the Node.js release website for new versions,
 // compare the available ones with the ones we use in this repo
 // and returns whether we should update or not
-const checkIfThereAreNewVersions = async () => {
+const checkIfThereAreNewVersions = async (github) => {
   try {
     const { stdout: versionsOutput } = await exec(". ./functions.sh && get_versions", { shell: "bash" });
 
     const supportedVersions = versionsOutput.trim().split(" ");
 
-    let lsOutput = "";
     let latestSupportedVersions = {};
 
     for (let supportedVersion of supportedVersions) {
-      lsOutput = (await exec(`ls ${supportedVersion}`)).stdout;
+      const { stdout } = await exec(`ls ${supportedVersion}`);
 
-      const { stdout: fullVersionOutput } = await exec(`. ./functions.sh && get_full_version ./${supportedVersion}/${lsOutput.trim().split("\n")[0]}`, { shell: "bash" });
+      const { stdout: fullVersionOutput } = await exec(`. ./functions.sh && get_full_version ./${supportedVersion}/${stdout.trim().split("\n")[0]}`, { shell: "bash" });
 
       console.log(fullVersionOutput);
 
       latestSupportedVersions[supportedVersion] = { fullVersion: fullVersionOutput.trim() };
     }
 
-    const availableVersionsJson = await (await fetch('https://nodejs.org/download/release/index.json')).json();
+    const { data: availableVersionsJson } = await github.request('https://nodejs.org/download/release/index.json');
 
     // filter only more recent versions of availableVersionsJson for each major version in latestSupportedVersions' keys
     // e.g. if latestSupportedVersions = { "12": "12.22.10", "14": "14.19.0", "16": "16.14.0", "17": "17.5.0" }
@@ -58,15 +57,14 @@ const checkIfThereAreNewVersions = async () => {
 
 // a function that queries the Node.js unofficial release website for new musl versions and security releases,
 // and returns relevant information
-const checkForMuslVersionsAndSecurityReleases = async (versions) => {
+const checkForMuslVersionsAndSecurityReleases = async (github, versions) => {
   try {
-    let unofficialBuildsIndexText = await (await fetch('https://unofficial-builds.nodejs.org/download/release/index.json')).json();
+    const { data: unofficialBuildsIndexText } = await github.request('https://unofficial-builds.nodejs.org/download/release/index.json');
 
-    let unofficialBuildsWebsiteText = "";
     for (let version of Object.keys(versions)) {
-      unofficialBuildsWebsiteText = await (await fetch(`https://unofficial-builds.nodejs.org/download/release/v${versions[version].fullVersion}`)).text();
-      versions[version].muslBuildExists = unofficialBuildsWebsiteText.includes("musl");
+      const { data: unofficialBuildsWebsiteText } = await github.request(`https://unofficial-builds.nodejs.org/download/release/v${versions[version].fullVersion}`);
 
+      versions[version].muslBuildExists = unofficialBuildsWebsiteText.includes("musl");
       versions[version].isSecurityRelease = unofficialBuildsIndexText.find(indexVersion => indexVersion.version === `v${versions[version].fullVersion}`)?.security;
     }
     return versions;
@@ -76,29 +74,31 @@ const checkForMuslVersionsAndSecurityReleases = async (versions) => {
   }
 };
 
+export default async function(github) {
 // if there are no new versions, exit gracefully
 // if there are new versions,
 // check for musl builds
 // then run update.sh
-const { shouldUpdate, versions } = await checkIfThereAreNewVersions();
+  const { shouldUpdate, versions } = await checkIfThereAreNewVersions(github);
 
-if (!shouldUpdate) {
-  console.log("No new versions found. No update required.");
-  process.exit(0);
-} else {
-  const newVersions = await checkForMuslVersionsAndSecurityReleases(versions);
-  let updatedVersions = [];
-  for (let version of Object.keys(newVersions)) {
-    if (newVersions[version].muslBuildExists) {
-      const { stdout } = await exec(`./update.sh ${newVersions[version].isSecurityRelease ? "-s " : ""}${version}`);
-      console.log(stdout);
-      updatedVersions.push(newVersions[version].fullVersion);
-    } else {
-      console.log(`There's no musl build for version ${newVersions[version].fullVersion} yet.`);
-      process.exit(0);
+  if (!shouldUpdate) {
+    console.log("No new versions found. No update required.");
+    process.exit(0);
+  } else {
+    const newVersions = await checkForMuslVersionsAndSecurityReleases(github, versions);
+    let updatedVersions = [];
+    for (let version of Object.keys(newVersions)) {
+      if (newVersions[version].muslBuildExists) {
+        const { stdout } = await exec(`./update.sh ${newVersions[version].isSecurityRelease ? "-s " : ""}${version}`);
+        console.log(stdout);
+        updatedVersions.push(newVersions[version].fullVersion);
+      } else {
+        console.log(`There's no musl build for version ${newVersions[version].fullVersion} yet.`);
+        process.exit(0);
+      }
     }
-  };
-  console.log(`::set-output name=updated-versions::${updatedVersions.join(',')}`);
-  const { stdout } = (await exec(`git diff`));
-  console.log(stdout);
+    console.log(`::set-output name=updated-versions::${updatedVersions.join(',')}`);
+    const { stdout } = (await exec(`git diff`));
+    console.log(stdout);
+  }
 }

--- a/check-pr-status.mjs
+++ b/check-pr-status.mjs
@@ -7,22 +7,23 @@ import { setTimeout } from 'timers/promises';
 const tries = 10;
 const retryDelay = 30000;
 
-await setTimeout(retryDelay);
+export default async function(github, owner, repository, pull_number) {
+  const repo = repository.replace(new RegExp(`${owner}/`), '')
+  await setTimeout(retryDelay);
 
-for (let t = 0; t < tries; t++) {
-  try {
-    const [repo, pull_number] = process.argv.slice(2);
+  for (let t = 0; t < tries; t++) {
+    try {
+      const { data } = await github.rest.pulls.get({owner, repo, pull_number})
 
-    const data = await (await fetch(`https://api.github.com/repos/${repo}/pulls/${pull_number}`)).json();
-
-    console.log(data);
-    if (data.mergeable_state === 'clean') {
-      process.exit(0);
+      console.log(data);
+      if (data.mergeable_state === 'clean') {
+        process.exit(0);
+      }
+      await setTimeout(retryDelay);
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
     }
-    await setTimeout(retryDelay);
-  } catch (error) {
-    console.error(error);
-    process.exit(1);
   }
+  process.exit(1);
 }
-process.exit(1);

--- a/check-pr-status.mjs
+++ b/check-pr-status.mjs
@@ -7,8 +7,8 @@ import { setTimeout } from 'timers/promises';
 const tries = 10;
 const retryDelay = 30000;
 
-export default async function(github, owner, repository, pull_number) {
-  const repo = repository.replace(new RegExp(`${owner}/`), '')
+export default async function(github, repository, pull_number) {
+  const [owner, repo] = repository.split('/');
   await setTimeout(retryDelay);
 
   for (let t = 0; t < tries; t++) {


### PR DESCRIPTION
(this got too big to add as suggestion in the PR, sorry)

We use `actions/github-script` elsewhere, and it gives us a nice `github` client we can use instead of using `fetch`.

Make sure to ignore whitespace to make this reviewable at all: https://github.com/Pehesi97/docker-node/pull/27/files?w=1